### PR TITLE
Fix semantic errors in OpenAPI spec

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -148,7 +148,7 @@ paths:
                   $ref: '#/components/schemas/TextTranslatorFileInfo'
       security:
         - subscription_key: []
-  /api/texttranslator/v1.0/documents/{id}/files/{fileid}/content:
+  /api/texttranslator/v1.0/documents/{id}/files/{fileId}/content:
     get:
       tags:
         - Documents
@@ -265,7 +265,7 @@ paths:
           description: Not Found
       security:
         - subscription_key: []
-  /api/texttranslator/v1.0/documents/import/jobs/{jobid}:
+  /api/texttranslator/v1.0/documents/import/jobs/{jobId}:
     get:
       tags:
         - Documents


### PR DESCRIPTION
For the /api/texttranslator/v1.0/documents/{id}/files/{fileid}/content and /api/texttranslator/v1.0/documents/import/jobs/{jobid} endpoints, the "fileid" and "jobid" path paramaters do not match their paramater name declaration which is "fileId" and "jobId".

This commit fixes this casing mismatch, which in turn fixes the semantic errors in this OpenAPI spec.